### PR TITLE
Fix router-skipping bug in graph connect.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-dataflow",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Vega streaming dataflow graph.",
   "repository": {
     "type": "git",

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -186,13 +186,14 @@ function forEachNode(branch, fn) {
     if (!node.data && node.batch()) {
       if (router) {
         branch.splice(i, 0, (node = new Collector(this)));
+        router = false;
       } else {
         node.data = collector.data.bind(collector);
       }
     } 
 
     if (node.collector()) collector = node;
-    router = node.router() && !node.collector(); 
+    router = router || node.router() && !node.collector(); 
     fn(node, collector, i);
   }
 }


### PR DESCRIPTION
The router flag in graph connect should persist across non-router, non-collector nodes.
