### PR TITLE
Streamline Tuple and DataSource, revise _prev handling.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "browserify": "^10.2.6",
     "browserify-shim": "^3.8.9",
+    "browserify-versionify": "^1.0.4",
     "chai": "^3.0.0",
     "istanbul": "latest",
     "mocha": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-dataflow",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Vega streaming dataflow graph.",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   }],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "datalib": "^1.3.0",
+    "datalib": "^1.4.5",
     "vega-logging": "^1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-dataflow",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Vega streaming dataflow graph.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "browserify": "^10.2.6",
     "browserify-shim": "^3.8.9",
-    "browserify-versionify": "^1.0.4",
     "chai": "^3.0.0",
     "istanbul": "latest",
     "mocha": "^2.2.5",

--- a/src/Collector.js
+++ b/src/Collector.js
@@ -31,8 +31,8 @@ prototype.evaluate = function(input) {
   }
 
   if (input.reflow) {
-    input.mod = input.mod.concat(Tuple.idFilter(this._data, 
-      input.add, input.mod, input.rem));
+    input.mod = input.mod.concat(
+      Tuple.idFilter(this._data, input.add, input.mod, input.rem));
     input.reflow = false;
   }
 

--- a/src/DataSource.js
+++ b/src/DataSource.js
@@ -152,8 +152,9 @@ prototype.pipeline = function(pipeline) {
 
 prototype.finalize = function() {
   if (this._revises) {
-    for (var i=0, n=this._data.length; i<n; ++i) {
-      Tuple.reset_prev(this._data[i]);
+    var data = this.values();
+    for (var i=0, n=data.length; i<n; ++i) {
+      Tuple.reset_prev(data[i]);
     }
   }
 };

--- a/src/DataSource.js
+++ b/src/DataSource.js
@@ -127,6 +127,25 @@ prototype.pipeline = function(pipeline) {
   return this;
 };
 
+prototype.synchronize = function() {
+  var data = this._data, i, n;
+
+  if (data.length && data[0]._prev) {
+    for (i=0, n=data.length; i<n; ++i) {
+      Tuple.prev_update(data[i]);
+    }
+  }
+  if (this._collector) {
+    data = this._collector.data();
+    if (data.length && data[0]._prev) {
+      for (i=0, n=data.length; i<n; ++i) {
+        Tuple.prev_update(data[i]);
+      }
+    }
+  }
+  return this;
+};
+
 prototype.listener = function() { 
   return DataSourceListener(this).addListener(this._inputNode);
 };

--- a/src/DataSource.js
+++ b/src/DataSource.js
@@ -151,8 +151,10 @@ prototype.pipeline = function(pipeline) {
 };
 
 prototype.finalize = function() {
-  if (this._revises) for (var i=0, n=this._data.length; i<n; ++i) {
-    Tuple.reset_prev(this._data[i]);
+  if (this._revises) {
+    for (var i=0, n=this._data.length; i<n; ++i) {
+      Tuple.reset_prev(this._data[i]);
+    }
   }
 };
 

--- a/src/DataSource.js
+++ b/src/DataSource.js
@@ -2,8 +2,7 @@ var log = require('vega-logging'),
     ChangeSet = require('./ChangeSet'), 
     Collector = require('./Collector'),
     Tuple = require('./Tuple'),
-    Node = require('./Node'), // jshint ignore:line
-    SENTINEL = require('./Sentinel');
+    Node = require('./Node'); // jshint ignore:line
 
 function DataSource(graph, name, facet) {
   this._graph = graph;
@@ -80,20 +79,14 @@ prototype.values = function(data) {
   return this;
 };
 
-function set_prev(d) {
-  if (d._prev === undefined) d._prev = SENTINEL;
-}
-
 prototype.revises = function(p) {
   if (!arguments.length) return this._revises;
 
   // If we've not needed prev in the past, but a new dataflow node needs it now
   // ensure existing tuples have prev set.
   if (!this._revises && p) {
-    this._data.forEach(set_prev);
-
-    // New tuples that haven't yet been merged into _data
-    this._input.add.forEach(set_prev); 
+    this._data.forEach(Tuple.init_prev);
+    this._input.add.forEach(Tuple.init_prev); // new tuples haven't been merged
   }
 
   this._revises = this._revises || p;
@@ -119,27 +112,82 @@ prototype.fire = function(input) {
 prototype.pipeline = function(pipeline) {
   if (!arguments.length) return this._pipeline;
 
-  var ds = this;
+  this._inputNode = DataSourceInput(this);
+  this._outputNode = DataSourceOutput(this);
 
-  // Add a collector to materialize the output of pipeline operators.
-  if (pipeline.length) {
-    ds._collector = new Collector(this._graph);
-    pipeline.push(ds._collector);
-    ds._revises = pipeline.some(function(p) { return p.revises(); });
-    ds._mutates = pipeline.some(function(p) { return p.mutates(); });
+  var graph = this._graph,
+      revises = 0,
+      mutates = 0,
+      collector = this._inputNode,
+      i, node, router, collects;
+
+  for (i=0; i<pipeline.length; ++i) {
+    node = pipeline[i];
+
+    if (!node._collector && node.batch()) {
+      if (router) {
+        node = new Collector(graph);
+        pipeline.splice(i, 0, node);
+        router = false;
+      } else {
+        node._collector = collector;
+      }
+    }
+
+    if ((collects = node.collector())) collector = node;
+    router = router || node.router() && !collects;
+    revises = revises || node.revises();
+    mutates = mutates || node.mutates();
   }
+  if (router) pipeline.push(collector = new Collector(graph));
 
-  // Input/output nodes masquerade as collector nodes, so they need to
-  // have a `data` function. dsData is used if a collector isn't available.
-  function dsData() { return ds._data; }
+  pipeline.unshift(this._inputNode);
+  pipeline.push(this._outputNode);
+  this._collector = collector;
+  this._revises = !!revises;
+  this._mutates = !!mutates;
+  this._graph.connect(this._pipeline = pipeline);
+  return this;
+};
 
-  // Input node applies the datasource's delta, and propagates it to 
-  // the rest of the pipeline. It receives touches to reflow data.
-  var input = new Node(this._graph)
+prototype.finalize = function() {
+  if (this._revises) for (var i=0, n=this._data.length; i<n; ++i) {
+    Tuple.reset_prev(this._data[i]);
+  }
+};
+
+prototype.listener = function() { 
+  return DataSourceListener(this).addListener(this._inputNode);
+};
+
+prototype.addListener = function(l) {
+  if (l instanceof DataSource) {
+    (this._collector || this._inputNode).addListener(l.listener());
+  } else {
+    this._outputNode.addListener(l);      
+  }
+  return this;
+};
+
+prototype.removeListener = function(l) {
+  this._outputNode.removeListener(l);
+};
+
+prototype.listeners = function(ds) {
+  return (ds ? this._collector || this._inputNode : this._outputNode)
+    .listeners();
+};
+
+// Input node applies the datasource's delta, and propagates it to 
+// the rest of the pipeline. It receives touches to reflow data.
+function DataSourceInput(ds) {
+  var input = new Node(ds._graph)
     .router(true)
     .collector(true);
 
-  input.data = dsData;
+  input.data = function() {
+    return ds._data;
+  };
 
   input.evaluate = function(input) {
     log.debug(input, ['input', ds._name]);
@@ -163,8 +211,8 @@ prototype.pipeline = function(pipeline) {
 
     // if reflowing, add any other tuples not currently in changeset
     if (input.reflow) {
-      delta.mod = delta.mod.concat(Tuple.idFilter(ds._data,
-        delta.add, delta.mod, delta.rem));
+      delta.mod = delta.mod.concat(
+        Tuple.idFilter(ds._data, delta.add, delta.mod, delta.rem));
     }
 
     // reset change list
@@ -177,24 +225,26 @@ prototype.pipeline = function(pipeline) {
     return out;
   };
 
-  pipeline.unshift(input);
+  return input;
+}
 
-  // Output node captures the last changeset seen by this datasource
-  // (needed for joins and builds) and materializes any nested data.
-  // If this datasource is faceted, materializes the values in the facet.
-  var output = new Node(this._graph)
+// Output node captures the last changeset seen by this datasource
+// (needed for joins and builds) and materializes any nested data.
+// If this datasource is faceted, materializes the values in the facet.
+function DataSourceOutput(ds) {
+  var output = new Node(ds._graph)
     .router(true)
     .reflows(true)
     .collector(true);
 
-  output.data = ds._collector ?
-    ds._collector.data.bind(ds._collector) :
-    dsData;
+  output.data = function() {
+    return ds._collector ? ds._collector.data() : ds._data;
+  };
 
   output.evaluate = function(input) {
     log.debug(input, ['output', ds._name]);
 
-    var output = ChangeSet.create(input, true);
+    var out = ChangeSet.create(input, true);
 
     if (ds._facet) {
       ds._facet.values = ds.values();
@@ -202,92 +252,43 @@ prototype.pipeline = function(pipeline) {
     }
 
     ds._output = input;
-    output.data[ds._name] = 1;
-    return output;
+    out.data[ds._name] = 1;
+    return out;
   };
 
-  pipeline.push(output);
+  return output;
+}
 
-  this._pipeline = pipeline;
-  this._graph.connect(ds._pipeline);
-  return this;
-};
-
-prototype.finalize = function() {
-  if (!this._revises) return;
-  for (var i=0, n=this._data.length; i<n; ++i) {
-    var x = this._data[i];
-    x._prev = (x._prev === undefined) ? undefined : SENTINEL;
-  }
-};
-
-prototype.listener = function() { 
-  var l = new Node(this._graph).router(true),
-      dest = this,
-      prev = this._revises ? null : undefined;
+function DataSourceListener(ds) {
+  var l = new Node(ds._graph).router(true);
 
   l.evaluate = function(input) {
-    if (dest.mutates()) {
-      // Tuple derivation is expensive. Only do so if dest datasource has
-      // operators that mutate, and thus would pollute the source data.
-      dest._srcMap = dest._srcMap || {}; // to propagate tuples correctly
-      var map = dest._srcMap,
-          output  = ChangeSet.create(input);
+    // Tuple derivation carries a cost. So only derive if the pipeline has
+    // operators that mutate, and thus would override the source data.
+    if (ds.mutates()) {  
+      var map = ds._srcMap || (ds._srcMap = {}), // to propagate tuples correctly
+          output = ChangeSet.create(input);
 
       output.add = input.add.map(function(t) {
-        var d = dest._mutates ? 
-          Tuple.derive(t, t._prev !== undefined ? t._prev : prev) : 
-          t;
-        return (map[t._id] = d);
+        return (map[t._id] = Tuple.derive(t, ds._revises));
       });
 
       output.mod = input.mod.map(function(t) {
-        var o = map[t._id];
-        return (o._prev = t._prev, o);
+        return Tuple.rederive(t, map[t._id]);
       });
 
       output.rem = input.rem.map(function(t) { 
         var o = map[t._id];
-        map[t._id] = null;
-        return (o._prev = t._prev, o);
+        return (map[t._id] = null, o);
       });
 
-      return (dest._input = output);
+      return (ds._input = output);
     } else {
-      return (dest._input = input);
+      return (ds._input = input);
     }
   };
 
-  l.addListener(this._pipeline[0]);
   return l;
-};
-
-prototype.addListener = function(l) {
-  if (l instanceof DataSource) {
-    if (this._collector) {
-      this._collector.addListener(l.listener());
-    } else {
-      this._pipeline[0].addListener(l.listener());
-    }
-  } else {
-    this._pipeline[this._pipeline.length-1].addListener(l);      
-  }
-
-  return this;
-};
-
-prototype.removeListener = function(l) {
-  this._pipeline[this._pipeline.length-1].removeListener(l);
-};
-
-prototype.listeners = function(ds) {
-  if (ds) {
-    return this._collector ?
-      this._collector.listeners() :
-      this._pipeline[0].listeners();
-  } else {
-    return this._pipeline[this._pipeline.length-1].listeners();
-  }
-};
+}
 
 module.exports = DataSource;

--- a/src/DataSource.js
+++ b/src/DataSource.js
@@ -130,19 +130,17 @@ prototype.pipeline = function(pipeline) {
 prototype.synchronize = function() {
   var data = this._data, i, n;
 
-  if (data.length && data[0]._prev) {
+  for (i=0, n=data.length; i<n; ++i) {
+    Tuple.prev_update(data[i]);
+  }
+
+  if (this._inputNode !== this._collector) {
+    data = this._collector.data();
     for (i=0, n=data.length; i<n; ++i) {
       Tuple.prev_update(data[i]);
     }
   }
-  if (this._collector) {
-    data = this._collector.data();
-    if (data.length && data[0]._prev) {
-      for (i=0, n=data.length; i<n; ++i) {
-        Tuple.prev_update(data[i]);
-      }
-    }
-  }
+
   return this;
 };
 

--- a/src/DataSource.js
+++ b/src/DataSource.js
@@ -9,12 +9,14 @@ function DataSource(graph, name, facet) {
   this._name = name;
   this._data = [];
   this._source = null;
-  this._facet = facet;
-  this._input = ChangeSet.create();
+  this._facet  = facet;
+  this._input  = ChangeSet.create();
   this._output = null; // Output changeset
 
+  this._inputNode  = null;
+  this._outputNode = null;
   this._pipeline  = null; // Pipeline of transformations.
-  this._collector = null; // Collector to materialize output of pipeline
+  this._collector = null; // Collector to materialize output of pipeline.
   this._mutates = false;  // Does any pipeline operator mutate tuples?
 }
 
@@ -150,7 +152,7 @@ prototype.listener = function() {
 
 prototype.addListener = function(l) {
   if (l instanceof DataSource) {
-    (this._collector || this._inputNode).addListener(l.listener());
+    this._collector.addListener(l.listener());
   } else {
     this._outputNode.addListener(l);      
   }
@@ -162,8 +164,7 @@ prototype.removeListener = function(l) {
 };
 
 prototype.listeners = function(ds) {
-  return (ds ? this._collector || this._inputNode : this._outputNode)
-    .listeners();
+  return (ds ? this._collector : this._outputNode).listeners();
 };
 
 // Input node applies the datasource's delta, and propagates it to 

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -1,4 +1,4 @@
-var util = require('datalib/src/util'),
+var dl = require('datalib'),
     Heap = require('./Heap'),
     ChangeSet = require('./ChangeSet'),
     DataSource = require('./DataSource'),
@@ -90,7 +90,7 @@ prototype.signalValues = function(names) {
 
 prototype.signalRef = function(ref) {
   if (!Array.isArray(ref)) {
-    ref = util.field(ref);
+    ref = dl.field(ref);
   }
 
   var value = this.signal(ref[0]).value();

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -2,7 +2,6 @@ var util = require('datalib/src/util'),
     Heap = require('./Heap'),
     ChangeSet = require('./ChangeSet'),
     DataSource = require('./DataSource'),
-    Collector = require('./Collector'),
     Signal = require('./Signal'),
     Deps = require('./Dependencies');
 
@@ -172,76 +171,51 @@ prototype.propagate = function(pulse, node, stamp) {
   }
 };
 
-// Connect a branch of dataflow nodes. 
-// Dependencies are wired to the nearest collector. 
-function forEachNode(branch, fn) {
-  var node, collector, router, i;
-
-  for (i=0; i<branch.length; ++i) {
-    node = branch[i];
-
-    // Share collectors between batch transforms. We can reuse an
-    // existing collector unless a router node has come after it,
-    // in which case, we splice in a new collector.
-    if (!node.data && node.batch()) {
-      if (router) {
-        branch.splice(i, 0, (node = new Collector(this)));
-        router = false;
-      } else {
-        node.data = collector.data.bind(collector);
-      }
-    } 
-
-    if (node.collector()) collector = node;
-    router = router || node.router() && !node.collector(); 
-    fn(node, collector, i);
-  }
-}
-
 prototype.connect = function(branch) {
-  var graph = this;
+  var collector, node, data, signals, i, n, j, m;
 
-  forEachNode.call(this, branch, function(n, c, i) {
-    var data = n.dependency(Deps.DATA),
-        signals = n.dependency(Deps.SIGNALS);
+  // connect the pipeline
+  for (i=0, n=branch.length; i<n; ++i) {
+    node = branch[i];
+    if (node.collector()) collector = node;
 
-    if (data.length > 0) {
-      data.forEach(function(d) { 
-        graph.data(d)
-          .revises(n.revises())
-          .addListener(c);
-      });
+    data = node.dependency(Deps.DATA);
+    for (j=0, m=data.length; j<m; ++j) {
+      this.data(data[j])
+        .revises(node.revises())
+        .addListener(collector);
     }
 
-    if (signals.length > 0) {
-      signals.forEach(function(s) { graph.signal(s).addListener(c); });
+    signals = node.dependency(Deps.SIGNALS);
+    for (j=0, m=signals.length; j<m; ++j) {
+      this.signal(signals[j]).addListener(collector);
     }
 
-    if (i > 0) {
-      branch[i-1].addListener(branch[i]);
-    }
-  });
+    if (i > 0) branch[i-1].addListener(node);
+  }
 
   return branch;
 };
 
 prototype.disconnect = function(branch) {
-  var graph = this;
+  var collector, node, data, signals, i, n, j, m;
 
-  forEachNode.call(this, branch, function(n, c) {
-    var data = n.dependency(Deps.DATA),
-        signals = n.dependency(Deps.SIGNALS);
+  for (i=0, n=branch.length; i<n; ++i) {
+    node = branch[i];
+    if (node.collector()) collector = node;
 
-    if (data.length > 0) {
-      data.forEach(function(d) { graph.data(d).removeListener(c); });
+    data = node.dependency(Deps.DATA);
+    for (j=0, m=data.length; j<m; ++j) {
+      this.data(data[j]).removeListener(collector);
     }
 
-    if (signals.length > 0) {
-      signals.forEach(function(s) { graph.signal(s).removeListener(c); });
+    signals = node.dependency(Deps.SIGNALS);
+    for (j=0, m=signals.length; j<m; ++j) {
+      this.signal(signals[j]).removeListener(collector);
     }
 
-    n.disconnect();  
-  });
+    node.disconnect();
+  }
 
   return branch;
 };

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -181,9 +181,7 @@ prototype.connect = function(branch) {
 
     data = node.dependency(Deps.DATA);
     for (j=0, m=data.length; j<m; ++j) {
-      this.data(data[j])
-        .revises(node.revises())
-        .addListener(collector);
+      this.data(data[j]).addListener(collector);
     }
 
     signals = node.dependency(Deps.SIGNALS);

--- a/src/Node.js
+++ b/src/Node.js
@@ -8,10 +8,9 @@ function Node(graph) {
 var Flags = Node.Flags = {
   Router:     0x01, // Responsible for propagating tuples, cannot be skipped.
   Collector:  0x02, // Holds a materialized dataset, pulse node to reflow.
-  Mutates:    0x04, // Sets properties of incoming tuples,
-  Revises:    0x08, // Requires tuple previous values.
-  Reflows:    0x10, // Forwards a reflow pulse.
-  Batch:      0x20  // Performs batch data processing, needs collector.
+  Mutates:    0x04, // Sets properties of incoming tuples.
+  Reflows:    0x08, // Forwards a reflow pulse.
+  Batch:      0x10  // Performs batch data processing, needs collector.
 };
 
 var prototype = Node.prototype;
@@ -72,11 +71,6 @@ prototype.collector = function(state) {
 prototype.mutates = function(state) {
   if (!arguments.length) return (this._flags & Flags.Mutates);
   return this._setf(Flags.Mutates, state);
-};
-
-prototype.revises = function(state) {
-  if (!arguments.length) return (this._flags & Flags.Revises);
-  return this._setf(Flags.Revises, state);
 };
 
 prototype.reflows = function(state) {

--- a/src/Sentinel.js
+++ b/src/Sentinel.js
@@ -1,1 +1,0 @@
-module.exports = {'sentinel': 1};

--- a/src/Tuple.js
+++ b/src/Tuple.js
@@ -5,7 +5,10 @@ var tupleID = 0;
 // the outside environment. 
 function ingest(datum) {
   datum = (datum === Object(datum)) ? datum : {data: datum};
-  return (datum._id = ++tupleID, datum);
+  var id = ++tupleID;
+  datum._id = id;
+  if (datum._prev) datum._prev._id = id;
+  return datum;
 }
 
 function idMap(a, ids) {
@@ -33,18 +36,24 @@ module.exports = {
   },
 
   rederive: function(d, t) {
-    if (d._prev) copy(d._prev, t._prev);
     return copy(d, t);
   },
 
   set: function(t, k, v) {
-    return t[k] === v ? false : (t[k] = v, true);
+    return t[k] === v ? 0 : (t[k] = v, 1);
   },
 
-  prev: function(t, stamp) {
-    var p = t._prev || (t._prev = {_id: t._id});
+  prev: function(t) {
+    return t._prev || t;
+  },
+
+  prev_init: function(t) {
+    if (!t._prev) { t._prev = {_id: t._id}; }
+  },
+
+  prev_update: function(t) {
     // TODO update copy to handle tuple values with their own _prev.
-    return (!stamp || p._stamp === stamp) ? p : (p._stamp = stamp, copy(t, p));
+    if (t._prev) { copy(t, t._prev); }
   },
 
   reset: function() { tupleID = 0; },

--- a/src/Tuple.js
+++ b/src/Tuple.js
@@ -6,7 +6,7 @@ var tupleID = 0;
 function ingest(datum, prev) {
   datum = (datum === Object(datum)) ? datum : {data: datum};
   datum._id = ++tupleID;
-  datum._prev = prev;//(prev === undefined) ? prev : (prev || SENTINEL);
+  datum._prev = prev;
   if (prev) prev._id = datum._id;
   return datum;
 }
@@ -33,8 +33,7 @@ module.exports = {
 
   derive: function(d, prev) {
     // TODO is it safe to use a raw previous object here?
-    //return ingest(Object.create(d), p);
-    var p = d._prev !== undefined ? d._prev : prev;
+    var p = d._prev !== undefined ? d._prev : (prev ? null : undefined);
     return ingest(copy(d), p ? copy(p) : p);
   },
 

--- a/src/Tuple.js
+++ b/src/Tuple.js
@@ -7,7 +7,7 @@ function ingest(datum) {
   datum = (datum === Object(datum)) ? datum : {data: datum};
   var id = ++tupleID;
   datum._id = id;
-  if (datum._prev) datum._prev._id = id;
+  if (datum._prev) datum._prev = null;
   return datum;
 }
 
@@ -52,8 +52,12 @@ module.exports = {
   },
 
   prev_update: function(t) {
-    // TODO update copy to handle tuple values with their own _prev.
-    if (t._prev) { copy(t, t._prev); }
+    var p = t._prev, k, v;
+    if (p) for (k in t) {
+      if (k !== '_prev' && k !== '_id') {
+        p[k] = ((v=t[k]) instanceof Object && v._prev) ? v._prev : v;
+      }
+    }
   },
 
   reset: function() { tupleID = 0; },

--- a/src/Tuple.js
+++ b/src/Tuple.js
@@ -48,7 +48,10 @@ module.exports = {
     if (u === v) {
       return false;
     } else if ((p = t._prev) !== undefined) {
-      if (p === null) { t._prev = (p = copy(t)); }
+      if (p === null) {
+        t._prev = (p = copy(t));
+        p._id = t._id;
+      }
       p[k] = u;
     }
 

--- a/src/Tuple.js
+++ b/src/Tuple.js
@@ -1,12 +1,8 @@
 var tupleID = 0;
 
-// Object.create is expensive. So, when ingesting, trust that the
-// datum is an object that has been appropriately sandboxed from 
-// the outside environment. 
 function ingest(datum) {
   datum = (datum === Object(datum)) ? datum : {data: datum};
-  var id = ++tupleID;
-  datum._id = id;
+  datum._id = ++tupleID;
   if (datum._prev) datum._prev = null;
   return datum;
 }

--- a/src/Tuple.js
+++ b/src/Tuple.js
@@ -32,7 +32,6 @@ module.exports = {
   idMap: idMap,
 
   derive: function(d, prev) {
-    // TODO is it safe to use a raw previous object here?
     var p = d._prev !== undefined ? d._prev : (prev ? null : undefined);
     return ingest(copy(d), p ? copy(p) : p);
   },
@@ -44,10 +43,10 @@ module.exports = {
 
   // WARNING: operators should only call this once per timestamp!
   set: function(t, k, v) {
-    var u = t[k], p;
-    if (u === v) {
-      return false;
-    } else if ((p = t._prev) !== undefined) {
+    var u = t[k];
+        p = t._prev;
+
+    if (p !== undefined) {
       if (p === null) {
         t._prev = (p = copy(t));
         p._id = t._id;
@@ -55,21 +54,20 @@ module.exports = {
       p[k] = u;
     }
 
-    t[k] = v;
-    return true;
+    return u === v ? false : (t[k] = v, true);
   },
 
   prev: function(t) {
     return t._prev || t;
   },
 
-  init_prev: function(d) {
-    if (d._prev === undefined) d._prev = null;
+  init_prev: function(t) {
+    if (t._prev === undefined) t._prev = null;
   },
 
-  reset_prev: function(d) {
-    var p = d._prev, k;
-    for (k in p) p[k] = d[k];
+  reset_prev: function(t) {
+    var p = t._prev, k;
+    for (k in p) p[k] = t[k];
   },
 
   reset: function() { tupleID = 0; },

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ module.exports = {
   Dependencies: require('./Dependencies'),
   Graph:        require('./Graph'),
   Node:         require('./Node'),
-  Sentinel:     require('./Sentinel'),
   Signal:       require('./Signal'),
   Tuple:        require('./Tuple'),
   debug:        require('vega-logging').debug

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -9,57 +9,37 @@ describe('Node', function() {
     var n = new Node();
     assert.notOk(n.router());
     assert.notOk(n.collector());
-    assert.notOk(n.revises());
     assert.notOk(n.batch());
 
     n.router(true);
     assert.ok(n.router());
     assert.notOk(n.collector());
-    assert.notOk(n.revises());
     assert.notOk(n.batch());
-/*
+
     n.collector(true);
     assert.ok(n.router());
     assert.ok(n.collector());
-    assert.notOk(n.revises());
     assert.notOk(n.batch());
-
-    n.revises(true);
-    assert.ok(n.router());
-    assert.ok(n.collector());
-    assert.ok(n.revises());
-    assert.ok(n.batch());
 
     n.batch(true);
     assert.ok(n.router());
     assert.ok(n.collector());
-    assert.ok(n.revises());
     assert.ok(n.batch());
 
     n.router(false);
     assert.notOk(n.router());
     assert.ok(n.collector());
-    assert.ok(n.revises());
     assert.ok(n.batch());
 
     n.collector(false);
     assert.notOk(n.router());
     assert.notOk(n.collector());
-    assert.ok(n.revises());
-    assert.ok(n.batch());
-
-    n.revises(false);
-    assert.notOk(n.router());
-    assert.notOk(n.collector());
-    assert.notOk(n.revises());
     assert.ok(n.batch());
 
     n.batch(false);
     assert.notOk(n.router());
     assert.notOk(n.collector());
-    assert.notOk(n.revises());
     assert.notOk(n.batch());
-*/
   });
 
 });

--- a/test/tuple.test.js
+++ b/test/tuple.test.js
@@ -2,7 +2,6 @@
 
 var assert = require('chai').assert;
 var Tuple = require('../src/Tuple');
-var SENTINEL = require('../src/Sentinel');
 
 describe('Tuple', function() {
 
@@ -17,20 +16,26 @@ describe('Tuple', function() {
 
     d = Tuple.ingest(o, null);
     assert.equal(d._id, 2);
-    assert.strictEqual(d._prev, SENTINEL);
+    assert.strictEqual(d._prev, null);
 
     d = Tuple.ingest(5, p);
     assert.equal(d._id, 3);
     assert.equal(d.data, 5);
     assert.strictEqual(d._prev, p);
     assert.equal(d._prev.data, 3);
+    assert.equal(p._id, d._id);
   });
 
-  it('should derive inheriting tuples', function() {
-    var o = {a: 5};
+  it('should copy on derive', function() {
+    var o = Tuple.ingest({a: 5});
     var d = Tuple.derive(o);
     assert.equal(d.a, 5);
-    assert.strictEqual(d.__proto__, o);
+    assert.isUndefined(d._prev);
+
+    o = Tuple.ingest({a: 2}, {a: 3});
+    d = Tuple.derive(o);
+    assert.equal(d.a, 2);
+    assert.equal(d._prev.a, 3);
   });
 
   it('should set values', function() {

--- a/test/tuple.test.js
+++ b/test/tuple.test.js
@@ -13,18 +13,15 @@ describe('Tuple', function() {
     assert.equal(d._id, 1);
     assert.equal(d.a, 5);
     assert.strictEqual(d, o);
-    assert.notOk(Tuple.has_prev(d));
     assert.isUndefined(d._prev);
 
     d = Tuple.ingest(o, null);
     assert.equal(d._id, 2);
-    assert.notOk(Tuple.has_prev(d));
     assert.strictEqual(d._prev, SENTINEL);
 
     d = Tuple.ingest(5, p);
     assert.equal(d._id, 3);
     assert.equal(d.data, 5);
-    assert.ok(Tuple.has_prev(d));
     assert.strictEqual(d._prev, p);
     assert.equal(d._prev.data, 3);
   });
@@ -40,7 +37,7 @@ describe('Tuple', function() {
     var d = Tuple.ingest({a:5});
     assert.isTrue(Tuple.set(d, 'a', 7));
     assert.equal(d.a, 7);
-    assert.notOk(Tuple.has_prev(d));
+    assert.notOk(d._prev);
 
     d = Tuple.ingest({a:5}, null);
     assert.isTrue(Tuple.set(d, 'a', 7));

--- a/test/tuple.test.js
+++ b/test/tuple.test.js
@@ -14,16 +14,18 @@ describe('Tuple', function() {
     assert.strictEqual(d, o);
     assert.isUndefined(d._prev);
 
-    d = Tuple.ingest(o, null);
+    d = Tuple.ingest(o);
     assert.equal(d._id, 2);
-    assert.strictEqual(d._prev, null);
+    assert.isUndefined(d._prev, null);
 
-    d = Tuple.ingest(5, p);
+    d = Tuple.ingest(3);
+    Tuple.prev(d, 1);
+    d.data = 5;
     assert.equal(d._id, 3);
     assert.equal(d.data, 5);
-    assert.strictEqual(d._prev, p);
+    assert.isDefined(d._prev);
     assert.equal(d._prev.data, 3);
-    assert.equal(p._id, d._id);
+    assert.equal(d._prev._id, d._id);
   });
 
   it('should copy on derive', function() {
@@ -31,25 +33,22 @@ describe('Tuple', function() {
     var d = Tuple.derive(o);
     assert.equal(d.a, 5);
     assert.isUndefined(d._prev);
-
-    o = Tuple.ingest({a: 2}, {a: 3});
-    d = Tuple.derive(o);
-    assert.equal(d.a, 2);
-    assert.equal(d._prev.a, 3);
   });
 
   it('should set values', function() {
     var d = Tuple.ingest({a:5});
     assert.isTrue(Tuple.set(d, 'a', 7));
     assert.equal(d.a, 7);
-    assert.notOk(d._prev);
+    assert.isUndefined(d._prev);
 
-    d = Tuple.ingest({a:5}, null);
+    d = Tuple.ingest({a:5});
+    Tuple.prev(d, 1);
     assert.isTrue(Tuple.set(d, 'a', 7));
     assert.equal(d.a, 7);
     assert.equal(d._prev.a, 5);
 
-    d = Tuple.ingest(5, {data: 3});
+    d = Tuple.ingest(5);
+    Tuple.prev(d, 1);
     assert.isTrue(Tuple.set(d, 'data', 7));
     assert.equal(d.data, 7);
     assert.equal(d._prev.data, 5);

--- a/test/tuple.test.js
+++ b/test/tuple.test.js
@@ -19,7 +19,8 @@ describe('Tuple', function() {
     assert.isUndefined(d._prev, null);
 
     d = Tuple.ingest(3);
-    Tuple.prev(d, 1);
+    Tuple.prev_init(d);
+    Tuple.prev_update(d);
     d.data = 5;
     assert.equal(d._id, 3);
     assert.equal(d.data, 5);
@@ -37,22 +38,24 @@ describe('Tuple', function() {
 
   it('should set values', function() {
     var d = Tuple.ingest({a:5});
-    assert.isTrue(Tuple.set(d, 'a', 7));
+    assert.equal(Tuple.set(d, 'a', 7), 1);
     assert.equal(d.a, 7);
     assert.isUndefined(d._prev);
 
     d = Tuple.ingest({a:5});
-    Tuple.prev(d, 1);
-    assert.isTrue(Tuple.set(d, 'a', 7));
+    Tuple.prev_init(d);
+    Tuple.prev_update(d);
+    assert.equal(Tuple.set(d, 'a', 7), 1);
     assert.equal(d.a, 7);
     assert.equal(d._prev.a, 5);
 
     d = Tuple.ingest(5);
-    Tuple.prev(d, 1);
-    assert.isTrue(Tuple.set(d, 'data', 7));
+    Tuple.prev_init(d);
+    Tuple.prev_update(d);
+    assert.equal(Tuple.set(d, 'data', 7), 1);
     assert.equal(d.data, 7);
     assert.equal(d._prev.data, 5);
-    assert.isFalse(Tuple.set(d, 'data', 7));
+    assert.equal(Tuple.set(d, 'data', 7), 0);
   });
 
   it('should reset tuple ids', function() {


### PR DESCRIPTION
Two major changes:
- Simplify the Tuple class for smaller, more efficient code.
- Make Tuple `_prev` object inherit from the current tuple. This will allow the `_prev` object to act as a proper tuple in its own right, simplifying downstream management (e.g., by aggregators).
