### PR TITLE
Introduce producer-type node

### DIFF
--- a/src/DataSource.js
+++ b/src/DataSource.js
@@ -93,7 +93,7 @@ prototype.pipeline = function(pipeline) {
   if (!arguments.length) return this._pipeline;
 
   var graph = this._graph,
-      collector, status;
+      status;
 
   pipeline.unshift(this._inputNode = DataSourceInput(this));
   status = graph.preprocess(pipeline);

--- a/src/DataSource.js
+++ b/src/DataSource.js
@@ -111,25 +111,7 @@ prototype.pipeline = function(pipeline) {
 };
 
 prototype.synchronize = function() {
-  var pipeline = this._pipeline,
-      tids = {}, cids = {},
-      node, collector, data, i, n, j, m, d, id;
-
-  for (i=0, n=pipeline.length; i<n; ++i) {
-    node = pipeline[i];
-    collector = node._collector || (node.collector() && node);
-    if (cids[collector._id] || !collector) continue;
-
-    for (j=0, data=collector.data(), m=data.length; j<m; ++j) {
-      id = (d = data[j])._id;
-      if (tids[id]) continue; 
-      Tuple.prev_update(d);
-      tids[id] = 1; 
-    }
-
-    cids[collector._id] = 1;
-  }
-
+  this._graph.synchronize(this._pipeline);
   return this;
 };
 

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -245,22 +245,19 @@ prototype.disconnect = function(branch) {
 };
 
 prototype.synchronize = function(branch) {
-  var tids = {}, cids = {},
-      node, collector, data, i, n, j, m, d, id;
+  var ids = {},
+      node, data, i, n, j, m, d, id;
 
   for (i=0, n=branch.length; i<n; ++i) {
     node = branch[i];
-    collector = node._collector || (node.collector() && node);
-    if (cids[collector._id] || !collector) continue;
+    if (!node.collector()) continue;
 
-    for (j=0, data=collector.data(), m=data.length; j<m; ++j) {
+    for (j=0, data=node.data(), m=data.length; j<m; ++j) {
       id = (d = data[j])._id;
-      if (tids[id]) continue; 
+      if (ids[id]) continue; 
       Tuple.prev_update(d);
-      tids[id] = 1; 
+      ids[id] = 1; 
     }
-
-    cids[collector._id] = 1;
   }
 
   return this;

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -3,6 +3,7 @@ var dl = require('datalib'),
     ChangeSet = require('./ChangeSet'),
     DataSource = require('./DataSource'),
     Collector = require('./Collector'),
+    Tuple = require('./Tuple'),
     Signal = require('./Signal'),
     Deps = require('./Dependencies');
 
@@ -241,6 +242,28 @@ prototype.disconnect = function(branch) {
   }
 
   return branch;
+};
+
+prototype.synchronize = function(branch) {
+  var tids = {}, cids = {},
+      node, collector, data, i, n, j, m, d, id;
+
+  for (i=0, n=branch.length; i<n; ++i) {
+    node = branch[i];
+    collector = node._collector || (node.collector() && node);
+    if (cids[collector._id] || !collector) continue;
+
+    for (j=0, data=collector.data(), m=data.length; j<m; ++j) {
+      id = (d = data[j])._id;
+      if (tids[id]) continue; 
+      Tuple.prev_update(d);
+      tids[id] = 1; 
+    }
+
+    cids[collector._id] = 1;
+  }
+
+  return this;
 };
 
 prototype.reevaluate = function(pulse, node) {

--- a/src/Node.js
+++ b/src/Node.js
@@ -8,9 +8,10 @@ function Node(graph) {
 var Flags = Node.Flags = {
   Router:     0x01, // Responsible for propagating tuples, cannot be skipped.
   Collector:  0x02, // Holds a materialized dataset, pulse node to reflow.
-  Mutates:    0x04, // Sets properties of incoming tuples.
-  Reflows:    0x08, // Forwards a reflow pulse.
-  Batch:      0x10  // Performs batch data processing, needs collector.
+  Produces:   0x04, // Produces new tuples. 
+  Mutates:    0x08, // Sets properties of incoming tuples.
+  Reflows:    0x10, // Forwards a reflow pulse.
+  Batch:      0x20  // Performs batch data processing, needs collector.
 };
 
 var prototype = Node.prototype;
@@ -66,6 +67,11 @@ prototype.router = function(state) {
 prototype.collector = function(state) {
   if (!arguments.length) return (this._flags & Flags.Collector);
   return this._setf(Flags.Collector, state);
+};
+
+prototype.produces = function(state) {
+  if (!arguments.length) return (this._flags & Flags.Produces);
+  return this._setf(Flags.Produces, state);
 };
 
 prototype.mutates = function(state) {


### PR DESCRIPTION
A new `Produces` flag identifies nodes that generate new tuples. When a branch of the dataflow graph contains such nodes, Collectors are automatically inserted after them. The logic for this has also been extracted from `DataSource.pipeline` into `Graph.preprocess`. An updated `synchronize` method (which has been moved to `Graph` as well) traverses a dataflow branch and updates the previous values of tuples via Collectors. 
