### PR TITLE
Fixed Facet transform key cache issue

### DIFF
--- a/src/transforms/Facet.js
+++ b/src/transforms/Facet.js
@@ -64,16 +64,18 @@ prototype.transform = function(_, pulse) {
   this._group = _.group || {};
   this._targets.active = 0; // reset list of active subflows
 
+  pulse.visit(pulse.REM, function(t) {
+    var k = cache.get(t._id);
+    if (k !== undefined) {
+      cache.delete(t._id);
+      subflow(k).rem(t);
+    }
+  });
+
   pulse.visit(pulse.ADD, function(t) {
     var k = key(t);
     cache.set(t._id, k);
     subflow(k).add(t);
-  });
-
-  pulse.visit(pulse.REM, function(t) {
-    var k = cache.get(t._id);
-    cache.delete(t._id);
-    subflow(k).rem(t);
   });
 
   if (rekey || pulse.modified(key.fields)) {


### PR DESCRIPTION
This is intended to fix an issue with key cache in Facet transform if the following two cases ever happen:
1. In the same pulse, data records with same `_id` exist in both `pulse.ADD` and `pulse.REM` (e.g. in one of my use cases, `{_id: 201, start: 1.5, end: 2.5}` in `pulse.ADD` and `{_id: 201, start: 0, end: 1.5}` in `pulse.REM`)
2. The `pulse.REM` includes a data record with same` _id` that has been previously removed and thus the cache doesn't have the value for the `_id`.

I'm still not sure whether these two are normal cases, but if they do happen (which is true in my cases), Line 74 in Facet.js will returns `undefined` for `k`, which is then passed to Line 76 without check, and  a sub flow with `undefined` key is created. which further led to errors in DataJoin [Line 71](https://github.com/vega/vega-encode/blob/master/src/DataJoin.js#L71) and view got messed up eventually.

The fix in this PR includes:
1. added the check for `k`, if it is undefined, the subflow won't be called.
2. swaps the order of handling `pulse.REM` and `pulse.ADD`, so that if the same `_id` exist in both `pulse.ADD` and `pulse.REM`, it won't be added first and then removed.

I'm not sure confident about whether this will cause any side effect to other part of the code. The current tests in my use cases look all fine.
