### PR TITLE
Fix the Relay Transform visit order

### DIFF
--- a/src/transforms/Relay.js
+++ b/src/transforms/Relay.js
@@ -30,7 +30,12 @@ prototype.transform = function(_, pulse) {
 
   if (_.derive) {
     out = pulse.fork();
-
+    
+    pulse.visit(pulse.REM, function(t) {
+      out.rem.push(lut[t._id]);
+      lut[t._id] = null;
+    });
+    
     pulse.visit(pulse.ADD, function(t) {
       var dt = derive(t);
       lut[t._id] = dt;
@@ -39,11 +44,6 @@ prototype.transform = function(_, pulse) {
 
     pulse.visit(pulse.MOD, function(t) {
       out.mod.push(rederive(t, lut[t._id]));
-    });
-
-    pulse.visit(pulse.REM, function(t) {
-      out.rem.push(lut[t._id]);
-      lut[t._id] = null;
     });
   }
 


### PR DESCRIPTION
This is intended to fix an issue in Relay transform if the following use case ever happens:

1. the upstream `pulse.ADD` contains `{_id: 1}`, which is derived inside Relay as `{_id: 11}` to the `out.add`, and cached as `lut[1] = {_id: 11}`
2. later, the upstream sends in `{_id: 1}` inside both `pulse.ADD` and `pulse.REM`.

In the current implementation, the `pulse.ADD` is visited first, which creates a new derive, `{_id: 21}` to `out.add`, and overwrites `lut[1] = {_id: 21}`. Thereafter the `pulse.REM` is visited, which push the newly derived `{_id: 21}` into the `out.rem` as well. The previously derived `{_id: 11}` got lost in the process.

The expected behavior should be visiting the `pulse.REM` first, which push `{_id: 11}` into `out.rem`, and then visit the `pulse.ADD`, which push `{_id: 21}` into `out.add`.

This is somehow similar to an earlier PR [20](https://github.com/vega/vega-dataflow/pull/20). As a general principle, it seems to be safe to always visit REM before ADD within the same transform.