### PR TITLE
Fix cell access in Aggregate transform's rem

### DIFF
--- a/src/transforms/aggregate/Aggregate.js
+++ b/src/transforms/aggregate/Aggregate.js
@@ -214,12 +214,12 @@ function cellkey(x) {
 
 prototype.cellkey = cellkey;
 
-prototype.cell = function(key, t) {
+prototype.cell = function(key, t, rem) {
   var cell = this.value[key];
   if (!cell) {
     cell = this.value[key] = this.newcell(key, t);
     this._adds[this._alen++] = cell;
-  } else if (cell.num === 0 && this._drop && cell.stamp < this.stamp) {
+  } else if (cell.num === 0 && this._drop && cell.stamp < this.stamp && !rem) {
     cell.stamp = this.stamp;
     this._adds[this._alen++] = cell;
   } else if (cell.stamp < this.stamp) {
@@ -288,10 +288,10 @@ prototype.add = function(t) {
 
 prototype.rem = function(t) {
   var key = this.cellkey(t),
-      cell = this.cell(key, t),
+      cell = this.cell(key, t, true),
       agg, i, n;
 
-  cell.num -= 1;
+  if (cell.num > 0) cell.num -= 1;
   if (this._countOnly) return;
 
   if (cell.store) cell.data.rem(t);

--- a/src/transforms/aggregate/Aggregate.js
+++ b/src/transforms/aggregate/Aggregate.js
@@ -214,12 +214,12 @@ function cellkey(x) {
 
 prototype.cellkey = cellkey;
 
-prototype.cell = function(key, t, rem) {
+prototype.cell = function(key, t) {
   var cell = this.value[key];
   if (!cell) {
     cell = this.value[key] = this.newcell(key, t);
     this._adds[this._alen++] = cell;
-  } else if (cell.num === 0 && this._drop && cell.stamp < this.stamp && !rem) {
+  } else if (cell.num === 0 && this._drop && cell.stamp < this.stamp) {
     cell.stamp = this.stamp;
     this._adds[this._alen++] = cell;
   } else if (cell.stamp < this.stamp) {
@@ -288,10 +288,10 @@ prototype.add = function(t) {
 
 prototype.rem = function(t) {
   var key = this.cellkey(t),
-      cell = this.cell(key, t, true),
+      cell = this.cell(key, t),
       agg, i, n;
 
-  if (cell.num > 0) cell.num -= 1;
+  cell.num -= 1;
   if (this._countOnly) return;
 
   if (cell.store) cell.data.rem(t);
@@ -337,7 +337,8 @@ prototype.changes = function(out) {
       cell, key, i, n;
 
   if (prev) for (key in prev) {
-    rem.push(prev[key].tuple);
+    cell = prev[key];
+    if (!drop || cell.num) rem.push(cell.tuple);
   }
 
   for (i=0, n=this._alen; i<n; ++i) {


### PR DESCRIPTION
Inside Aggregate transform's `rem` function [L291](https://github.com/vega/vega-dataflow/blob/master/src/transforms/aggregate/Aggregate.js#L291), when `this.cell()` is called, it is possible condition at [L222](https://github.com/vega/vega-dataflow/blob/master/src/transforms/aggregate/Aggregate.js#L222) can hit, and caused the cell that is supposed to be removed is added to `this._adds`, which eventually caused unexpected item added to downstream.

I tried to fix it by adding a flag so that if `this.cell()` is called from `rem`, it won't hit the condition at [L222](https://github.com/vega/vega-dataflow/blob/master/src/transforms/aggregate/Aggregate.js#L222). In addition, I added the check inside `rem` so that if the num is already 0, it won't subtract. 

I tested in my project and so far no issue. But I don't fully understand this piece of code yet, so don't feel confident about this PR. Feel free to close it and make cleaner fixes. Thanks!